### PR TITLE
Feature/failure modal

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,7 +16,9 @@ const App: FC = () => {
   useEffect(() => {
     const getData = async () => {
       const data = await fetchInventory(INVENTORY_URI);
-
+      if (data.length == 0) {
+        dispatch(setModalState(modalTypes.FAILURE));
+      }
       if (!state.inventory.length) {
         dispatch(setInventory(data));
       }

--- a/src/api/authorization.ts
+++ b/src/api/authorization.ts
@@ -19,19 +19,24 @@ const getUser = async (url: string): Promise<Response> => {
   return response;
 };
 
-export const login = async (rfid: string): Promise<UserResponse> => {
+export const login = async (rfid: string): Promise<UserResponse | null> => {
   const url = LOGIN_URI(rfid);
   const response = await getUser(url);
-  const json = await response.json();
-  return json as UserResponse;
+  if (response.ok) {
+    const json = await response.json();
+    return json as UserResponse;
+  } else return null;
 };
 
 export const handleRfid = async (rfid: string): Promise<User | null> => {
   const user = await login(rfid);
-  if (user.count) {
-    // As it returns a weird response
-    const { pk, saldo, first_name } = user.results[0]; // The first and only user
-    return { pk, balance: saldo, first_name };
+  if (user) {
+    //error in req
+    if (user.count) {
+      //user OK
+      const { pk, saldo, first_name } = user.results[0]; // The first and only user
+      return { pk, balance: saldo, first_name };
+    } else return { pk: -1, balance: -1, first_name: "-1" };
   }
   return null;
 };

--- a/src/components/Modal/ErrorModal.tsx
+++ b/src/components/Modal/ErrorModal.tsx
@@ -5,6 +5,7 @@ const CompleteModal: FC = () => {
   return (
     <Container>
       <h3> En feil oppsto! </h3>
+      <p> Det kan hende at OW er nede </p>
       <p> Vennligst logg ut, og prøv igjen</p>
     </Container>
   );

--- a/src/components/Modal/FailureModal.tsx
+++ b/src/components/Modal/FailureModal.tsx
@@ -1,0 +1,27 @@
+import React, { FC } from "react";
+import styled from "styled-components";
+
+const CompleteModal: FC = () => {
+  return (
+    <Container>
+      <h3> Det ser ut til at OW er nede! </h3>
+      <p>
+        Nibble4 er avhengig av at OW er oppe å kjører. Gjerne meld fra i
+        @support kanalen i slack, eller send en mail til appkom@online.ntnu.no
+      </p>
+      <p>
+        Hvis du tror dette er en feil, gjerne trykk på den gule pilen og skann
+        kortet ditt på nytt
+      </p>
+    </Container>
+  );
+};
+
+export default CompleteModal;
+
+const Container = styled.div`
+  text-align: center;
+  width: 80%;
+  margin-left: auto;
+  margin-right: auto;
+`;

--- a/src/components/Modal/FailureModal.tsx
+++ b/src/components/Modal/FailureModal.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from "react";
 import styled from "styled-components";
 
-const CompleteModal: FC = () => {
+const FailureModal: FC = () => {
   return (
     <Container>
       <h3> Det ser ut til at OW er nede! </h3>
@@ -18,7 +18,7 @@ const CompleteModal: FC = () => {
   );
 };
 
-export default CompleteModal;
+export default FailureModal;
 
 const Container = styled.div`
   text-align: center;

--- a/src/components/Modal/FailureModal.tsx
+++ b/src/components/Modal/FailureModal.tsx
@@ -4,7 +4,7 @@ import styled from "styled-components";
 const FailureModal: FC = () => {
   return (
     <Container>
-      <h3> Det ser ut til at OW er nede! </h3>
+      <h3> Uff da, her skjedde en feil </h3>
       <p>
         Nibble4 er avhengig av at dotkom sine systemer er oppe å kjører. Gjerne
         meld fra i @support kanalen i slack, eller send en mail til

--- a/src/components/Modal/FailureModal.tsx
+++ b/src/components/Modal/FailureModal.tsx
@@ -6,8 +6,9 @@ const CompleteModal: FC = () => {
     <Container>
       <h3> Det ser ut til at OW er nede! </h3>
       <p>
-        Nibble4 er avhengig av at OW er oppe å kjører. Gjerne meld fra i
-        @support kanalen i slack, eller send en mail til appkom@online.ntnu.no
+        Nibble4 er avhengig av at dotkom sine systemer er oppe å kjører. Gjerne
+        meld fra i @support kanalen i slack, eller send en mail til
+        appkom@online.ntnu.no
       </p>
       <p>
         Hvis du tror dette er en feil, gjerne trykk på den gule pilen og skann

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -10,7 +10,7 @@ import PurchaseModal from "./PurchaseModal";
 import CompleteModal from "./CompleteModal";
 import ErrorModal from "./ErrorModal";
 import InactiveModal from "./InactiveModal";
-
+import FailureModal from "./FailureModal";
 const Modal: FC = () => {
   const { state, dispatch } = useContext(StateContext);
   const { modalState } = state;
@@ -29,6 +29,7 @@ const Modal: FC = () => {
       {modalState == modalTypes.COMPLETE ? <CompleteModal /> : null}
       {modalState == modalTypes.ERROR ? <ErrorModal /> : null}
       {modalState == modalTypes.INACTIVE ? <InactiveModal /> : null}
+      {modalState == modalTypes.FAILURE ? <FailureModal /> : null}
     </Container>,
     document.getElementById("root")!
   );
@@ -43,7 +44,7 @@ const Container = styled.div`
 
   width: 400px;
   height: 400px;
-
+  z-index: 100;
   margin: auto;
   margin-top: 10%;
   border-radius: 25px;

--- a/src/pages/LoginPage/Scanner/Login.tsx
+++ b/src/pages/LoginPage/Scanner/Login.tsx
@@ -13,6 +13,8 @@ import { Redirect } from "react-router-dom";
 import { setUser } from "state/actions";
 import { StateContext } from "state/state";
 import { registerCardRoute } from "utility/routes";
+import { modalTypes } from "types/modal";
+import { setModalState } from "state/actions";
 
 const Login: FC = () => {
   const inputRef = useRef<HTMLInputElement>(null);
@@ -40,7 +42,11 @@ const Login: FC = () => {
     event.preventDefault();
     if (!rfid.trim()) return;
     const user = await handleRfid(rfid);
-    if (user) dispatch(setUser(user));
+    if (!user) {
+      dispatch(setModalState(modalTypes.FAILURE));
+      return;
+    }
+    if (user.pk >= 0) dispatch(setUser(user));
     else setRegisterCard(true);
   };
 

--- a/src/pages/LoginPage/index.tsx
+++ b/src/pages/LoginPage/index.tsx
@@ -7,6 +7,7 @@ import Scanner from "./Scanner";
 import Register from "pages/LoginPage/Register";
 import { StateContext } from "state/state";
 import { shopRoute } from "utility/routes";
+import Modal from "components/Modal";
 
 type RegisterLocation = {
   register?: boolean;
@@ -30,6 +31,7 @@ const LoginPage: FC = () => {
         <CardReader />
       </Card>
       <Instructions />
+      <Modal />
     </Container>
   );
 };

--- a/src/state/state.tsx
+++ b/src/state/state.tsx
@@ -22,7 +22,7 @@ const initialState: State = {
   inventory: [],
   category: "Alt",
   cart: {},
-  modalState: modalTypes.DISABLED,
+  modalState: modalTypes.FAILURE,
 };
 
 const getIncrementedCartItem = (id: number, state: State): CartItem => {

--- a/src/state/state.tsx
+++ b/src/state/state.tsx
@@ -22,7 +22,7 @@ const initialState: State = {
   inventory: [],
   category: "Alt",
   cart: {},
-  modalState: modalTypes.FAILURE,
+  modalState: modalTypes.DISABLED,
 };
 
 const getIncrementedCartItem = (id: number, state: State): CartItem => {

--- a/src/types/modal.ts
+++ b/src/types/modal.ts
@@ -4,4 +4,5 @@ export enum modalTypes {
   ERROR = "ERROR",
   DISABLED = "DISABLED",
   INACTIVE = "INACTIVE",
+  FAILURE = "FAILURE",
 }


### PR DESCRIPTION
closes #69 

Added a new modal that gets displayed whenever nibble detects if OW is down. Currently it shows up under these conditions:
- Whenever a user tries to log in, but nibble4 doesnt get a response ok.
- If it cant retrieve the inventory

If the orderline endpoint is down, the already implemented error-modal gets displayed.